### PR TITLE
gradient truncation in BPTT

### DIFF
--- a/nematus/layers.py
+++ b/nematus/layers.py
@@ -135,6 +135,7 @@ def param_init_gru(options, params, prefix='gru', nin=None, dim=None):
 def gru_layer(tparams, state_below, options, prefix='gru', mask=None,
               emb_dropout=None,
               rec_dropout=None,
+              truncate_gradient=-1,
               profile=False,
               **kwargs):
     nsteps = state_below.shape[0]
@@ -201,6 +202,7 @@ def gru_layer(tparams, state_below, options, prefix='gru', mask=None,
                                 non_sequences=shared_vars,
                                 name=pp(prefix, '_layers'),
                                 n_steps=nsteps,
+                                truncate_gradient=truncate_gradient,
                                 profile=profile,
                                 strict=True)
     rval = [rval]
@@ -279,6 +281,7 @@ def gru_cond_layer(tparams, state_below, options, prefix='gru',
                    context_mask=None, emb_dropout=None,
                    rec_dropout=None, ctx_dropout=None,
                    pctx_=None,
+                   truncate_gradient=-1,
                    profile=False,
                    **kwargs):
 
@@ -401,6 +404,7 @@ def gru_cond_layer(tparams, state_below, options, prefix='gru',
                                     non_sequences=[pctx_, context, rec_dropout, ctx_dropout]+shared_vars,
                                     name=pp(prefix, '_layers'),
                                     n_steps=nsteps,
+                                    truncate_gradient=truncate_gradient,
                                     profile=profile,
                                     strict=True)
     return rval

--- a/nematus/nmt.py
+++ b/nematus/nmt.py
@@ -1643,3 +1643,7 @@ if __name__ == '__main__':
     args = parser.parse_args()
 
     train(**vars(args))
+
+#    Profile peak GPU memory usage by uncommenting next line and enabling theano CUDA memory profiling (http://deeplearning.net/software/theano/tutorial/profiling.html)
+#    print theano.sandbox.cuda.theano_allocated()
+

--- a/nematus/nmt.py
+++ b/nematus/nmt.py
@@ -226,6 +226,7 @@ def build_encoder(tparams, options, trng, use_noise, x_mask=None, sampling=False
                                             mask=x_mask,
                                             emb_dropout=emb_dropout,
                                             rec_dropout=rec_dropout,
+                                            truncate_gradient=options['encoder_truncate_gradient'],
                                             profile=profile)
 
 
@@ -243,6 +244,7 @@ def build_encoder(tparams, options, trng, use_noise, x_mask=None, sampling=False
                                              mask=xr_mask,
                                              emb_dropout=emb_dropout_r,
                                              rec_dropout=rec_dropout_r,
+                                             truncate_gradient=options['encoder_truncate_gradient'],
                                              profile=profile)
 
     # context will be the concatenation of forward and backward rnns
@@ -323,6 +325,7 @@ def build_model(tparams, options):
                                             emb_dropout=emb_dropout_d,
                                             ctx_dropout=ctx_dropout_d,
                                             rec_dropout=rec_dropout_d,
+                                            truncate_gradient=options['decoder_truncate_gradient'],
                                             profile=profile)
     # hidden states of the decoder gru
     proj_h = proj[0]
@@ -428,6 +431,7 @@ def build_sampler(tparams, options, use_noise, trng, return_alignment=False):
                                             emb_dropout=emb_dropout_d,
                                             ctx_dropout=ctx_dropout_d,
                                             rec_dropout=rec_dropout_d,
+                                            truncate_gradient=options['decoder_truncate_gradient'],
                                             profile=profile)
     # get the next hidden state
     next_state = proj[0]
@@ -664,7 +668,7 @@ def build_full_sampler(tparams, options, use_noise, trng, greedy=False):
     (sample, state, probs), updates = theano.scan(decoder_step,
                         outputs_info=[init_w, init_state, None],
                         non_sequences=[ctx, pctx_, target_dropout, emb_dropout_d, rec_dropout_d, ctx_dropout_d]+shared_vars,
-                        n_steps=n_steps)
+                        n_steps=n_steps, truncate_gradient=options['decoder_truncate_gradient'],)
 
     print >>sys.stderr, 'Building f_sample...',
     if greedy:
@@ -992,6 +996,8 @@ def train(dim_word=512,  # word vector dimensionality
           prior_model=None, # Prior model file, used for MAP
           tie_encoder_decoder_embeddings=False, # Tie the input embeddings of the encoder and the decoder (first factor only)
           tie_decoder_embeddings=False, # Tie the input embeddings of the decoder with the softmax output embeddings
+          encoder_truncate_gradient=-1, # Truncate BPTT gradients in the encoder to this value. Use -1 for no truncation
+          decoder_truncate_gradient=-1, # Truncate BPTT gradients in the decoder to this value. Use -1 for no truncation
     ):
 
     # Model options
@@ -1593,6 +1599,10 @@ if __name__ == '__main__':
                          help='size of maxibatch (number of minibatches that are sorted by length) (default: %(default)s)')
     training.add_argument('--objective', choices=['CE', 'MRT'], default='CE',
                          help='training objective. CE: cross-entropy minimization (default); MRT: Minimum Risk Training (https://www.aclweb.org/anthology/P/P16/P16-1159.pdf)')
+    training.add_argument('--encoder_truncate_gradient', type=int, default=-1, metavar='INT',
+                         help="truncate BPTT gradients in the encoder to this value. Use -1 for no truncation (default: %(default)s)")
+    training.add_argument('--decoder_truncate_gradient', type=int, default=-1, metavar='INT',
+                         help="truncate BPTT gradients in the encoder to this value. Use -1 for no truncation (default: %(default)s)")
 
     finetune = training.add_mutually_exclusive_group()
     finetune.add_argument('--finetune', action="store_true",

--- a/test/test_train_bigmem.sh
+++ b/test/test_train_bigmem.sh
@@ -23,5 +23,5 @@ mkdir -p models
   --no_shuffle \
   --dispFreq 500 \
   --finish_after 500 \
-  --encoder_truncate_gradient 15 \
-  --decoder_truncate_gradient 15
+  --encoder_truncate_gradient -1 \
+  --decoder_truncate_gradient -1

--- a/test/test_train_bigmem.sh
+++ b/test/test_train_bigmem.sh
@@ -12,16 +12,16 @@ mkdir -p models
   --model models/model.npz \
   --datasets data/corpus.en data/corpus.de \
   --dictionaries data/vocab.en.json data/vocab.de.json \
-  --dim_word 256 \
-  --dim 512 \
+  --dim_word 500 \
+  --dim 1024 \
   --n_words_src 30000 \
   --n_words 30000 \
   --maxlen 50 \
   --optimizer adam \
   --lrate 0.0001 \
-  --batch_size 40 \
+  --batch_size 80 \
   --no_shuffle \
   --dispFreq 500 \
   --finish_after 500 \
-  --encoder_truncate_gradient -1 \
-  --decoder_truncate_gradient -1
+  --encoder_truncate_gradient 15 \
+  --decoder_truncate_gradient 15

--- a/test/test_train_verybigmem.sh
+++ b/test/test_train_verybigmem.sh
@@ -12,16 +12,16 @@ mkdir -p models
   --model models/model.npz \
   --datasets data/corpus.en data/corpus.de \
   --dictionaries data/vocab.en.json data/vocab.de.json \
-  --dim_word 256 \
-  --dim 512 \
+  --dim_word 500 \
+  --dim 2048 \
   --n_words_src 30000 \
   --n_words 30000 \
   --maxlen 50 \
   --optimizer adam \
   --lrate 0.0001 \
-  --batch_size 40 \
+  --batch_size 80 \
   --no_shuffle \
   --dispFreq 500 \
   --finish_after 500 \
-  --encoder_truncate_gradient -1 \
-  --decoder_truncate_gradient -1
+  --encoder_truncate_gradient 15 \
+  --decoder_truncate_gradient 15

--- a/test/test_train_verybigmem.sh
+++ b/test/test_train_verybigmem.sh
@@ -23,5 +23,5 @@ mkdir -p models
   --no_shuffle \
   --dispFreq 500 \
   --finish_after 500 \
-  --encoder_truncate_gradient 15 \
-  --decoder_truncate_gradient 15
+  --encoder_truncate_gradient -1 \
+  --decoder_truncate_gradient -1


### PR DESCRIPTION
Gradient truncation in backpropagation through time.

May reduce memory consumption when applied to the decoder, possibly doesn't make much difference when applied to the encoder, but it may be worth trying anyway.