### PR TITLE
Fix valid freq -1 case

### DIFF
--- a/nematus/data_iterator.py
+++ b/nematus/data_iterator.py
@@ -65,6 +65,9 @@ class TextIterator:
     def __iter__(self):
         return self
 
+    def __len__(self):
+        return sum([1 for _ in self])
+    
     def reset(self):
         if self.shuffle:
             self.source, self.target = shuffle.main([self.source_orig, self.target_orig], temporary=True)

--- a/nematus/nmt.py
+++ b/nematus/nmt.py
@@ -1193,17 +1193,22 @@ def train(dim_word=512,  # word vector dimensionality
 
     print 'Total compilation time: {0:.1f}s'.format(time.time() - comp_start)
 
+    if validFreq == -1 or saveFreq == -1 or sampleFreq == -1:
+        print 'Computing number of training batches'
+        num_batches = len(train)
+        print 'There are {} batches in the train set'.format(num_batches)
+
+        if validFreq == -1:
+            validFreq = num_batches
+        if saveFreq == -1:
+            saveFreq = num_batches
+        if sampleFreq == -1:
+            sampleFreq = num_batches
+    
     print 'Optimization'
 
     #save model options
     json.dump(model_options, open('%s.json' % saveto, 'wb'), indent=2)
-
-    if validFreq == -1:
-        validFreq = len(train[0])/batch_size
-    if saveFreq == -1:
-        saveFreq = len(train[0])/batch_size
-    if sampleFreq == -1:
-        sampleFreq = len(train[0])/batch_size
 
     valid_err = None
 


### PR DESCRIPTION
Giving validFreq/sampleFreq/saveFreq a -1 value broke things.

data iterator has a new function __len__ that returns the actual number of batches in the training set (after filtering)

nmt.py now uses that in case -1 was given to any of validFreq/sampleFreq/saveFreq