### PR TITLE
fix requirements in setup.py and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Nematus requires the following packages:
  - Theano >= 0.7 (and its dependencies).
 
 we recommend executing the following command in a Python virtual environment:
-   `pip install numpy numexpr cython tables theano`
+   `pip install numpy numexpr cython tables theano bottle`
 
 the following packages are optional, but *highly* recommended
 

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setuptools.setup(
                       'Theano',
                       'ipdb',
                       'bottle',
-                      'bottle-log'
+                      'bottle-log',
                       'paste'],
     dependency_links=['git+http://github.com/Theano/Theano.git#egg=Theano',],
     classifiers=['Development Status :: 3 - Alpha',


### PR DESCRIPTION
I tried to install nematus and I discovered a comma missing in setup.py. And I need to install `bottle` before running `python setup.py install`. Therefore, I added it to `README.md` pip command.